### PR TITLE
fix: リロード時もキャッチコピーアニメーション追加

### DIFF
--- a/src/components/Loader/animateGradients.ts
+++ b/src/components/Loader/animateGradients.ts
@@ -15,7 +15,7 @@ const commonCatchStyles = {
   WebkitTextFillColor: "transparent",
 };
 
-const durations = [0.1, 0.08, 0.1, 0.05, 0.1, 0.08];
+const durations = [0.1, 0.08, 0.1, 0.05, 0.1, 0.05];
 
 const opacities = [0.7, 0.8, 0.9, 0.9, 0.9, 1.0];
 

--- a/src/components/Loader/animation.ts
+++ b/src/components/Loader/animation.ts
@@ -6,6 +6,7 @@ const animation = () => {
     const loader = document.getElementById("loader");
     const body = document.body;
     const loaderCatch = ".loader-catch";
+    const heroCatch = ".hero-catch";
 
     if (loader?.classList.contains("fs-loading")) {
       const tl = gsap.timeline();
@@ -39,12 +40,14 @@ const animation = () => {
           duration: 0.7,
           ease: "power3.in",
         },
-      )
-        .add(() => {
-          loader?.classList.remove("loading");
-          loader?.classList.add("-z-10000");
-        })
-        .to(loader, { opacity: 0, display: "none" });
+      ).to(loader, { duration: 0.7 });
+
+      animateGradients(heroCatch, tl);
+
+      tl.add(() => {
+        loader?.classList.remove("loading");
+        loader?.classList.add("-z-10000");
+      }).to(loader, { opacity: 0, display: "none" });
     }
   });
 };


### PR DESCRIPTION
## 概要
リロード時もキャッチコピーのグラデーションアニメーション追加

## 主な変更点
- animation関数にanimateGradients()追記

## 関連するIssue
- feature-loading