### PR TITLE
fix: リロード時のページめくりアニメーションをpageFlipAnimation関数として格納

### DIFF
--- a/src/components/Loader/animateGradients.ts
+++ b/src/components/Loader/animateGradients.ts
@@ -1,5 +1,3 @@
-import { gsap } from "gsap";
-
 const gradients = [
   "linear-gradient(150deg,rgba(58, 129, 180, 1) 0%, rgba(255, 255, 255, 1) 15%, rgba(252, 176, 69, 1) 30%, rgba(211, 39, 81, 1) 50%, rgba(131, 58, 180, 1) 90%, rgba(58, 129, 180, 1) 100%)",
   "linear-gradient(150deg,rgba(131, 58, 180, 1) 0%, rgba(58, 129, 180, 1) 10%, rgba(255, 255, 255, 1) 25%, rgba(252, 176, 69, 1) 40%, rgba(211, 39, 81, 1) 60%, rgba(131, 58, 180, 1) 100%)",

--- a/src/components/Loader/animation.ts
+++ b/src/components/Loader/animation.ts
@@ -1,4 +1,5 @@
 import { animateGradients } from "./animateGradients";
+import pageFlipAnimation from "@/libs/pageFlipAnimation";
 import { gsap } from "gsap";
 
 const animation = () => {
@@ -27,20 +28,9 @@ const animation = () => {
     } else if (loader?.classList.contains("loading")) {
       const tl = gsap.timeline();
 
-      tl.fromTo(
-        loader,
-        {
-          scale: 2,
-          aspectRatio: "1/cos(30deg)",
-          clipPath: "polygon(0 0, 100% 0, 0 100%)",
-        },
-        {
-          xPercent: -100,
-          yPercent: -100,
-          duration: 0.7,
-          ease: "power3.in",
-        },
-      ).to(loader, { duration: 0.7 });
+      pageFlipAnimation(loader, tl);
+
+      tl.to(loader, { duration: 0.7 });
 
       animateGradients(heroCatch, tl);
 

--- a/src/libs/pageFlipAnimation.ts
+++ b/src/libs/pageFlipAnimation.ts
@@ -1,0 +1,23 @@
+const pageFlipAnimation = (
+  selector: HTMLElement | string,
+  tl: gsap.core.Timeline,
+) => {
+  tl.fromTo(
+    selector,
+    {
+      scale: 2,
+      aspectRatio: "1/cos(30deg)",
+      clipPath: "polygon(0 0, 100% 0, 0 100%)",
+    },
+    {
+      xPercent: -100,
+      yPercent: -100,
+      duration: 0.7,
+      ease: "power3.in",
+    },
+  );
+
+  return tl;
+};
+
+export default pageFlipAnimation;


### PR DESCRIPTION
## 概要
リロード時のページめくりアニメーションをpageFlipAnimation関数として格納

## 主な変更点
- Loaderのanimationから該当部分を書き出しlibs/pageFlipAnimation.tsに格納
- animation.tsでリロード時にpageFlipAnimationを呼び出し。

## 関連するIssue
- feature-pageFlip