### PR TITLE
feat: スマホメニューの背景のテキストアニメーションの実装・リファクタリング

### DIFF
--- a/src/components/Menu/index.astro
+++ b/src/components/Menu/index.astro
@@ -49,9 +49,19 @@ const barClass = (position: "top" | "middle" | "bottom") =>
       }
     </ul>
     <Btn text="Back to such" sm={true} />
-    <div class="menu-deco z-1">
-      <Catch h1={false} others="top-3 right-5 rotate-180 opacity-5" />
-      <Catch h1={false} others="left-5 bottom-3 opacity-5" />
+    <div id="menu-deco" class="menu-deco z-1">
+      <!-- <Catch
+        h1={false}
+        others="deco-top top-3 right-5 rotate-180 opacity-5 origin-bottom-left"
+      /> -->
+      <Catch
+        h1={false}
+        others="deco-top bottom-full left-[95%] rotate-180 opacity-5 origin-bottom-left"
+      />
+      <Catch
+        h1={false}
+        others="deco-bottom left-5 bottom-0 opacity-5 origin-bottom-left"
+      />
     </div>
   </nav>
 </div>

--- a/src/components/Menu/menuToggle.ts
+++ b/src/components/Menu/menuToggle.ts
@@ -1,4 +1,5 @@
 import openMenu from "./openMenu";
+import openBgTextAnimation from "./openBgTextAnimation";
 import closeMenu from "./closeMenu";
 
 const menuToggle = () => {
@@ -6,10 +7,21 @@ const menuToggle = () => {
   const menuEl = document.getElementById("sp-menu");
   const flipEl = document.getElementById("menu-flip");
 
+  let menuTimeline: GSAPTimeline | null = null;
+  let bgTextTimeline: GSAPTimeline | null = null;
+
+  if (!buttonEl || !menuEl || !flipEl) return;
+
   buttonEl?.addEventListener("click", () => {
+    menuTimeline?.kill();
+    bgTextTimeline?.kill();
+    menuTimeline = null;
+    bgTextTimeline = null;
+
     if (!buttonEl.classList.contains("is-open")) {
       if (flipEl && menuEl) {
-        openMenu({ flipEl, menuEl, buttonEl });
+        menuTimeline = openMenu({ flipEl, menuEl, buttonEl });
+        bgTextTimeline = openBgTextAnimation();
       }
     } else {
       if (flipEl && menuEl) {

--- a/src/components/Menu/openBgTextAnimation.ts
+++ b/src/components/Menu/openBgTextAnimation.ts
@@ -1,0 +1,82 @@
+import { gsap } from "gsap";
+
+const openBgTextAnimation = () => {
+  const textTop = document.querySelector("#menu-deco .deco-top");
+  const textBottom = document.querySelector("#menu-deco .deco-bottom");
+
+  return gsap
+    .timeline({
+      delay: 3.0,
+      repeat: -1,
+      repeatDelay: 3.0,
+    })
+    .fromTo(
+      textTop,
+      {
+        x: 0,
+        y: 0,
+        skewY: 0,
+        scale: 1.0,
+        rotate: 180,
+      },
+      {
+        x: 10,
+        y: -10,
+        skewY: -7,
+        scaleX: 1.02,
+        scaleY: 1.3,
+        rotate: 187,
+        duration: 0.1,
+        ease: "power1.in",
+      },
+    )
+    .fromTo(
+      textBottom,
+      {
+        x: 0,
+        y: 0,
+        skewY: 0,
+        scale: 1.0,
+        rotate: 0,
+      },
+      {
+        x: -10,
+        y: 10,
+        skewY: -7,
+        scaleX: 1.02,
+        scaleY: 1.3,
+        rotate: 7,
+        duration: 0.1,
+        ease: "power1.in",
+      },
+      "<",
+    )
+    .to(
+      textTop,
+      {
+        x: 0,
+        y: 0,
+        skewY: 0,
+        scale: 1.0,
+        rotate: 180,
+        duration: 0.1,
+        ease: "power1.in",
+      },
+      "<4.0",
+    )
+    .to(
+      textBottom,
+      {
+        x: 0,
+        y: 0,
+        skewY: 0,
+        scale: 1.0,
+        rotate: 0,
+        duration: 0.1,
+        ease: "power1.in",
+      },
+      "<",
+    );
+};
+
+export default openBgTextAnimation;


### PR DESCRIPTION
## 概要
スマホメニューの背景のテキストアニメーションの実装・リファクタリング

## 主な変更点
- menuToggleで開閉の検知・timelineをまとめて状態管理
- bgTextAnimationにてメニューの背景のテキストアニメーションを追加

## 補足
- openMenu, closeMenuで共通で使用するDOM要素はmenuToggleにて取得
- bgTextAnimationでは必要な要素はこの関数内で取得

## 関連するIssue
- feature/menuSP-open-animation