### PR TITLE
fix: timelineのkill後、初期位置に戻すためgsap.set追記

### DIFF
--- a/src/components/Works/initWorks.ts
+++ b/src/components/Works/initWorks.ts
@@ -1,6 +1,7 @@
 import enableGalleryScroll from "./enableGalleryScroll";
 import startGalleryLoop from "./startGalleryLoop";
 import startTextLoop from "./startTextLoop";
+import { gsap } from "gsap";
 
 const initWorks = () => {
   const sectionEl = document.getElementById("works");
@@ -16,9 +17,11 @@ const initWorks = () => {
 
   const stopAnimations = () => {
     galleryTimeline?.kill();
+    gsap.set(galleryList, { x: 0 });
     galleryTimeline = null;
 
     textLoopTimeline?.kill();
+    gsap.set(loopText, { x: 0 });
     textLoopTimeline = null;
   };
 


### PR DESCRIPTION
## 概要
timelineのkill後、初期位置に戻すためgsap.set追記

## 主な変更点
- initWorksにgsap.setで初期位置に戻す処理を追加

## 補足
- 各アニメーションの状態管理はinitWorks・スライダー及びテキストのループアニメーションは双方初期位置は{ x: 0 }のためinitWorksに記述

## 関連するIssue
- feature/works-animation