### PR TITLE
feat: Serviceセクションが画面内に入った時の背景色変更アニメーション

### DIFF
--- a/src/components/Concept/index.astro
+++ b/src/components/Concept/index.astro
@@ -5,7 +5,7 @@ import BoldText from "@/components/BoldText.astro";
 
 <section
   id="concept"
-  class="relative overflow-hidden bg-white portrait:lg:overflow-visible"
+  class="relative overflow-hidden portrait:lg:overflow-visible"
 >
   <div id="concept-fixed" class="relative h-lvh w-lvw p-1 md:p-2">
     <div
@@ -27,7 +27,7 @@ import BoldText from "@/components/BoldText.astro";
   </div>
   <div
     id="concept-main"
-    class="container-base m-auto flex flex-col bg-white opacity-0 duration-1000"
+    class="container-base m-auto flex flex-col opacity-0 duration-1000"
   >
     <h2
       class="pt-20 pb-16 text-right text-[1.72rem] font-bold tracking-widest md:pt-64 md:pb-48 md:text-[3.2rem] lg:py-48 2xl:pt-80 landscape:lg:text-left"

--- a/src/components/News/index.astro
+++ b/src/components/News/index.astro
@@ -4,7 +4,7 @@ import Item from "./Item.astro";
 import Btn from "@/components/Btn.astro";
 ---
 
-<section id="news" class="relative bg-white">
+<section id="news" class="relative bg-white pt-11 md:pt-4 lg:pt-36">
   <div class="container-base pt-16 pb-20 md:pb-48">
     <SectionTitle title="News" others="pb-10 lg:pb-17 xl:pb-20" />
     <Item />

--- a/src/components/Service/index.astro
+++ b/src/components/Service/index.astro
@@ -4,7 +4,7 @@ import Item from "./Item.astro";
 ---
 
 <section id="service" class="relative bg-white">
-  <div class="border-light-gray container-base border-t pb-11 md:py-4 lg:pb-36">
+  <div class="border-light-gray container-base border-t md:pt-4">
     <SectionTitle
       title="Service"
       others="pt-8 xl:pt-6 pb-9 lg:pb-11 xl:pb-16"

--- a/src/components/Works/index.astro
+++ b/src/components/Works/index.astro
@@ -1,12 +1,11 @@
 ---
-import cn from "@/libs/cn";
 import works from "@/data/works";
 import Gallery from "./Gallery.astro";
 ---
 
 <div
   id="works"
-  class="relative overflow-hidden bg-white pt-16 pb-50 md:pt-34 md:pb-85 lg:pb-96 xl:pt-50 xl:pb-104 2xl:pt-50 2xl:pb-140 portrait:lg:pt-80 portrait:lg:pb-120"
+  class="works relative overflow-hidden pt-16 pb-50 duration-300 md:pt-34 md:pb-85 lg:pb-96 xl:pt-50 xl:pb-104 2xl:pt-50 2xl:pb-140 portrait:lg:pt-80 portrait:lg:pb-120"
 >
   <div class="works-gallery relative z-10 w-max -translate-x-20">
     <ul id="works-list" class="works-list flex h-full w-full">
@@ -21,11 +20,11 @@ import Gallery from "./Gallery.astro";
     aria-hidden="true"
   >
     <span
-      class="font-en block px-7 text-8xl opacity-15 md:px-10 md:text-9xl lg:text-[240px]"
+      class="font-en block px-7 text-8xl md:px-10 md:text-9xl lg:text-[240px]"
       >We Are Strategists with Purpose.</span
     >
     <span
-      class="font-en block px-7 text-8xl opacity-15 md:px-10 md:text-9xl lg:text-[240px]"
+      class="font-en block px-7 text-8xl md:px-10 md:text-9xl lg:text-[240px]"
       >We Are Strategists with Purpose.</span
     >
   </div>

--- a/src/libs/initColorMode.ts
+++ b/src/libs/initColorMode.ts
@@ -1,4 +1,4 @@
-const initServiceColorMode = () => {
+const initColorMode = () => {
   const sectionEl = document.getElementById("service");
   const rootEl = document.getElementById("page-root");
 
@@ -17,4 +17,4 @@ const initServiceColorMode = () => {
   observer.observe(sectionEl);
 };
 
-export default initServiceColorMode;
+export default initColorMode;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -22,11 +22,11 @@ const { color = "light" } = Astro.props as Props;
 
     <Concept />
 
-    <Works color={color} />
+    <Works />
 
-    <Service color={color} />
+    <Service />
 
-    <News color={color} />
+    <News />
 
     <Company />
 
@@ -35,7 +35,7 @@ const { color = "light" } = Astro.props as Props;
 </Layout>
 
 <script>
-  import initServiceColorMode from "@/libs/initServiceColorMode";
+  import initColorMode from "@/libs/initColorMode";
 
-  initServiceColorMode();
+  initColorMode();
 </script>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -25,3 +25,31 @@
   display: block;
   line-height: 1.05;
 }
+
+#page-root[data-color="light"] #concept,
+#page-root[data-color="light"] #works,
+#page-root[data-color="light"] #service,
+#page-root[data-color="light"] #news {
+  background: #fff;
+  transition: 0.3s;
+}
+
+#page-root[data-color="light"] #works #loop-text {
+  color: #000;
+  opacity: 0.15;
+  transition: 0.3s;
+}
+
+#page-root[data-color="dark"] #concept,
+#page-root[data-color="dark"] #works,
+#page-root[data-color="dark"] #service,
+#page-root[data-color="dark"] #news {
+  background: var(--color-light-gray);
+  transition: 0.3s;
+}
+
+#page-root[data-color="dark"] #works #loop-text {
+  color: #fff;
+  opacity: 0.45;
+  transition: 0.3s;
+}

--- a/src/types/ColorMode.ts
+++ b/src/types/ColorMode.ts
@@ -1,5 +1,3 @@
-type ColorMode = {
-  color: "light" | "dark";
-};
+type ColorMode = "light" | "dark";
 
 export type { ColorMode };


### PR DESCRIPTION
## 概要
Serviceセクションが画面内に入った時の背景色変更アニメーション

## 主な変更点
- トップページ(pages/index.astro)のLayoutコンポーネント直下に#page-root作成
- initColorModeにてServiceセクションの表示・非表示確認→#page-rootのdatasetが変化
- datasetに併せ各セクションの背景及びテキストなどのカラー変更

## 補足
- カラー変更はglobal.cssにて設定
- AstroのSSRを活かすため、コンポーネント間を跨ぐstateやstoreは使用せず、IntersectionObserverにてdatasetを変更しCSSにてスタイリングを変更する方式を採用
- darkモードの解除の位置要検討・Serviceの非表示ではなくNewsの表示に合わせた方が良いかも。
- 今後リファクタリングする際、gsapのScrollTriggerのonEnter, onLeaveではなくIntersectionObserverを使用すること。※スクロール位置がセクションの途中だと再検知が難しいため。

## 関連するIssue
- feature/service-color-switch