### PR TITLE
fix: Worksのテキストのループアニメーション修正

### DIFF
--- a/src/components/News/initNewsColorChange.ts
+++ b/src/components/News/initNewsColorChange.ts
@@ -1,0 +1,24 @@
+import { gsap } from "gsap";
+import { ScrollTrigger } from "gsap/ScrollTrigger";
+
+const initNewsColorChange = () => {
+  gsap.registerPlugin(ScrollTrigger);
+
+  const rootEl = document.getElementById("page-root");
+  const trigger = document.getElementById("news");
+
+  if (!rootEl || !trigger) return;
+
+  const tl = gsap.timeline({
+    scrollTrigger: {
+      trigger,
+      onEnter: () => {
+        rootEl.dataset.color = "light";
+      },
+    },
+  });
+
+  return tl;
+};
+
+export default initNewsColorChange;

--- a/src/components/Service/initServiceColorChange.ts
+++ b/src/components/Service/initServiceColorChange.ts
@@ -1,0 +1,25 @@
+import { gsap } from "gsap";
+import { ScrollTrigger } from "gsap/ScrollTrigger";
+
+const initServiceColorChange = () => {
+  gsap.registerPlugin(ScrollTrigger);
+
+  const rootEl = document.getElementById("page-root");
+  const trigger = document.getElementById("service");
+
+  if (!rootEl || !trigger) return;
+
+  const tl = gsap.timeline({
+    scrollTrigger: {
+      trigger,
+      start: "top bottom",
+      onEnter: () => {
+        rootEl.dataset.color = "dark";
+      },
+    },
+  });
+
+  return tl;
+};
+
+export default initServiceColorChange;

--- a/src/components/Works/index.astro
+++ b/src/components/Works/index.astro
@@ -20,11 +20,11 @@ import Gallery from "./Gallery.astro";
     aria-hidden="true"
   >
     <span
-      class="font-en block px-7 text-8xl md:px-10 md:text-9xl lg:text-[240px]"
+      class="font-en block px-7 text-8xl md:px-14 md:text-9xl lg:text-[240px]"
       >We Are Strategists with Purpose.</span
     >
     <span
-      class="font-en block px-7 text-8xl md:px-10 md:text-9xl lg:text-[240px]"
+      class="font-en block px-7 text-8xl md:px-14 md:text-9xl lg:text-[240px]"
       >We Are Strategists with Purpose.</span
     >
   </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -30,26 +30,26 @@
 #page-root[data-color="light"] #works,
 #page-root[data-color="light"] #service,
 #page-root[data-color="light"] #news {
-  background: #fff;
-  transition: 0.3s;
+  background-color: #fff;
+  transition: background-color 0.3s;
 }
 
 #page-root[data-color="light"] #works #loop-text {
   color: #000;
   opacity: 0.15;
-  transition: 0.3s;
+  transition: color 0.3s;
 }
 
 #page-root[data-color="dark"] #concept,
 #page-root[data-color="dark"] #works,
 #page-root[data-color="dark"] #service,
 #page-root[data-color="dark"] #news {
-  background: var(--color-light-gray);
-  transition: 0.3s;
+  background-color: var(--color-light-gray);
+  transition: background-color 0.3s;
 }
 
 #page-root[data-color="dark"] #works #loop-text {
   color: #fff;
   opacity: 0.45;
-  transition: 0.3s;
+  transition: color 0.3s;
 }


### PR DESCRIPTION
## 概要
Worksのテキストのループアニメーション修正

## 主な変更点
- global.cssのtrainstionをcolorのみに指定
- 該当のWorksのテキスト以外にもgsapと競合する可能性あるためtransitionを指定して設定

## 補足
- Worksのテキストループのrepeat後の開始位置に違和感→Serviceセクションの表示により、背景色を変更する際に設定したglobal.cssのtransitionの設定と競合していたことが判明

## 関連するIssue
- fix/works-animation