### PR TITLE
fix: IntersectionObserverのrootMarginとthreshouldの調整(Serviceセクション検知で背景色変化)

### DIFF
--- a/src/components/News/Item.astro
+++ b/src/components/News/Item.astro
@@ -5,7 +5,7 @@ import newsItems from "@/data/newsItems";
 <ul class="news-articles">
   {
     newsItems.map((item) => (
-      <li class="group/item border-light-gray cursor-pointer border-b px-2 py-7 first:border-y md:py-8 lg:px-0 lg:py-11 xl:py-12 2xl:py-14">
+      <li class="group/item cursor-pointer border-b border-zinc-300 px-2 py-7 first:border-y md:py-8 lg:px-0 lg:py-11 xl:py-12 2xl:py-14">
         <span class="flex-col duration-200 group-hover/item:opacity-50 lg:flex lg:flex-row lg:items-center">
           <p class="font-menu pb-2 text-xs lg:pb-0 lg:pl-12 lg:text-lg">
             {item.date}

--- a/src/components/News/index.astro
+++ b/src/components/News/index.astro
@@ -4,10 +4,7 @@ import Item from "./Item.astro";
 import Btn from "@/components/Btn.astro";
 ---
 
-<section
-  id="news"
-  class="relative bg-white pt-11 md:pt-4 lg:pt-36 portrait:md:pt-0"
->
+<section id="news" class="relative bg-white pt-11 md:pt-4 lg:pt-36">
   <div class="container-base pt-16 pb-20 md:pb-48">
     <SectionTitle title="News" others="pb-10 lg:pb-17 xl:pb-20" />
     <Item />

--- a/src/components/Service/index.astro
+++ b/src/components/Service/index.astro
@@ -3,10 +3,7 @@ import SectionTitle from "@/components/SectionTitle.astro";
 import Item from "./Item.astro";
 ---
 
-<section
-  id="service"
-  class="relative bg-white portrait:md:pb-10 portrait:lg:pb-36"
->
+<section id="service" class="relative bg-white">
   <div class="container-base border-t border-zinc-300 md:pt-4">
     <SectionTitle
       title="Service"

--- a/src/libs/initColorMode.ts
+++ b/src/libs/initColorMode.ts
@@ -5,38 +5,35 @@ const initColorMode = () => {
 
   if (!serviceEl || !newsEl || !rootEl) return;
 
-  const serviceObserver = new IntersectionObserver((entries) => {
-    entries.forEach(
-      (entry) => {
-        if (entry.isIntersecting) {
-          rootEl.dataset.color = "dark";
-        } else {
-          if (entry.intersectionRatio <= 0.3 || !entry.isIntersecting) {
+  const isSp = window.matchMedia("(max-width: 799px)").matches;
+
+  const isPortrait = window.matchMedia(
+    "(orientation: portrait) and (min-width: 800px)",
+  ).matches;
+
+  const serviceObserver = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        if (!isPortrait) {
+          if (entry.isIntersecting) {
+            if ((entry.intersectionRatio >= 0, entry.intersectionRatio < 0.3)) {
+              rootEl.dataset.color = "light";
+            } else {
+              rootEl.dataset.color = "dark";
+            }
+          } else {
             rootEl.dataset.color = "light";
           }
         }
-      },
-
-      { threshold: [0, 0.3] },
-    );
-  });
+      });
+    },
+    {
+      rootMargin: "0px 0px 50% 0px",
+      threshold: [0, 0.3],
+    },
+  );
 
   serviceObserver.observe(serviceEl);
-
-  const newsObserver = new IntersectionObserver((entries) => {
-    entries.forEach(
-      (entry) => {
-        if (entry.isIntersecting) {
-          rootEl.dataset.color = "light";
-        } else if (entry.intersectionRatio > 0.3) {
-          rootEl.dataset.color = "dark";
-        }
-      },
-      { threshold: [0, 0.3] },
-    );
-  });
-
-  newsObserver.observe(newsEl);
 };
 
 export default initColorMode;


### PR DESCRIPTION
## 概要
initColorModeのリファクタリング・IntersectionObserverの調整

## 主な変更点
- Newsセクションの監視は行わず、Serviceセクションの監視のオプションをrootMarginとthresholdにて調整
- ipad(800px以上で縦長)では背景色の変更は行わないよう変更
- Tailwindでスタイルを調整

## 関連するIssue
- refactor/scroll-color-switch