### PR TITLE
feat: Serviceセクションのリストアイテムのスライドイン実装

### DIFF
--- a/src/components/Service/Item.astro
+++ b/src/components/Service/Item.astro
@@ -8,11 +8,11 @@ import Arrow from "@/components/Arrow.astro";
 >
   {
     serviceItems.map((item) => (
-      <li class="group/item relative cursor-pointer pb-4 md:w-3/10">
+      <li class="group/item relative h-full cursor-pointer pb-4 md:w-3/10">
         <span class="font-en absolute top-4 right-px z-10 pt-4 text-[50px] leading-1 text-white opacity-40 drop-shadow-md md:pt-0 md:text-3xl md:leading-none md:opacity-20 md:drop-shadow xl:text-5xl 2xl:text-6xl">
           {item.en}
         </span>
-        <div class="relative">
+        <div class="relative h-full">
           <div class="absolute h-full w-full rounded bg-black opacity-5 duration-300 group-hover/item:opacity-0 md:opacity-20" />
           <img src={item.src} class="w-full rounded" />
         </div>

--- a/src/components/Service/index.astro
+++ b/src/components/Service/index.astro
@@ -12,3 +12,9 @@ import Item from "./Item.astro";
     <Item />
   </div>
 </section>
+
+<script>
+  import startItemAnimation from "./startItemAnimation";
+
+  startItemAnimation();
+</script>

--- a/src/components/Service/startItemAnimation.ts
+++ b/src/components/Service/startItemAnimation.ts
@@ -1,0 +1,37 @@
+import { gsap } from "gsap";
+import { ScrollTrigger } from "gsap/ScrollTrigger";
+
+const startItemAnimation = () => {
+  const sectionEl = document.getElementById("service");
+
+  if (!sectionEl) return;
+
+  if (window.matchMedia("(min-width: 768px)").matches && sectionEl) {
+    gsap.registerPlugin(ScrollTrigger);
+
+    gsap
+      .timeline({
+        scrollTrigger: {
+          trigger: sectionEl,
+          start: "top 150%",
+          end: "bottom center",
+          once: true,
+        },
+      })
+      .fromTo(
+        ".service-list li",
+        {
+          y: 30,
+          opacity: 0,
+        },
+        {
+          y: 0,
+          stagger: 0.3,
+          duration: 0.5,
+          opacity: 1.0,
+        },
+      );
+  }
+};
+
+export default startItemAnimation;


### PR DESCRIPTION
## 概要
Serviceセクションのリストアイテムのスライドイン実装

## 主な変更点
- Serviceセクションのリストアイテムのスライドインを行うstartItemAnimationを実装

## 補足
- ScrollTriggerのstart位置がずれているので（確認した限りでは全てのコンポーネントにて）別途テストを行う予定。　※現状start: "top 150%"で問題なし。

## 関連するIssue
- feature/service-item-animation