### PR TITLE
fix: スライダーの非表示の設定をdisplayではなくvisibilityに変更

### DIFF
--- a/src/components/Hero/initSwiperManager.ts
+++ b/src/components/Hero/initSwiperManager.ts
@@ -22,20 +22,20 @@ const initSwiperManager = () => {
         onEnter: () => {
           if (!heroSwiper) {
             heroSwiper = createSwiper(heroSlider);
-            heroSlider.style.display = "block";
+            heroSlider.style.visibility = "visible";
           }
         },
         onLeave: () => {
           if (heroSwiper) {
             heroSwiper.destroy(true, true);
-            heroSlider.style.display = "none";
+            heroSlider.style.visibility = "hidden";
             heroSwiper = null;
           }
         },
         onEnterBack: () => {
           if (!heroSwiper) {
             heroSwiper = createSwiper(heroSlider);
-            heroSlider.style.display = "block";
+            heroSlider.style.visibility = "visible";
           }
         },
       },


### PR DESCRIPTION
## 概要
スライダーの非表示の設定をdisplayではなくvisibilityに変更

## 主な変更点
- Hero/initSwiperManager.tsにて、heroSlider.style.visibilityを操作するよう修正

## 補足
- Swiperより警告が出ていた理由は、display: noneを設定してしまうと、再度swiperインスタンスを生成するタイミングにて、スライダーが一見確認できなかったため、loopモードに必要なスライダーが足りていないと認識されたこと！ ※loop: slidesCount > 1としていても、タイミングによりdisplay: noneが効き、実行時にスライダーのDOM要素が消えている場合がある！！

## 関連するIssue
- fix/slider