### PR TITLE
feat: SPメニューの背景にグラデーションアニメーションを追加

### DIFF
--- a/src/animations/common/startTextGradientAnimation.ts
+++ b/src/animations/common/startTextGradientAnimation.ts
@@ -21,23 +21,30 @@ export const startTextGradientAnimation = ({
   selector,
   tl,
   color,
+  faded = false,
+  opacity = 1.0,
 }: {
   selector: string | HTMLElement;
   tl: GSAPTimeline;
   color?: string;
+  faded?: boolean;
+  opacity?: number;
 }) => {
+  const scale = faded ? 0.1 : 1;
+
   gradients.forEach((gradient, i) => {
     tl.to(selector, {
       ...commonCatchStyles,
       backgroundImage: gradient,
       duration: durations[i],
-      opacity: opacities[i],
+      opacity: opacities[i] * scale,
     });
   });
   tl.to(selector, {
     clearProps:
       "backgroundImage,backgroundClip,WebkitBackgroundClip,WebkitTextFillColor",
     color: color ? color : "black",
+    opacity: opacity,
     duration: 0.1,
   });
 

--- a/src/components/Menu/startMenuBgAnimation.ts
+++ b/src/components/Menu/startMenuBgAnimation.ts
@@ -1,84 +1,32 @@
+import { startTextGradientAnimation } from "@/animations/common/startTextGradientAnimation";
 import { gsap } from "gsap";
 
 const startMenuBgAnimation = () => {
   const textTop = document.querySelector("#menu-deco .deco-top");
   const textBottom = document.querySelector("#menu-deco .deco-bottom");
 
-  let tl = gsap.timeline({
-    delay: 3.0,
-    repeat: -1,
-    repeatDelay: 3.0,
-  });
+  if (!textTop || !textBottom) return;
 
-  tl.fromTo(
-    textTop,
-    {
-      x: 0,
-      y: 0,
-      skewY: 0,
-      scale: 1.0,
-      rotate: 180,
-    },
-    {
-      x: 10,
-      y: -10,
-      skewY: -7,
-      scaleX: 1.02,
-      scaleY: 1.3,
-      rotate: 187,
-      duration: 0.1,
-      ease: "power1.in",
-    },
-  )
-    .fromTo(
-      textBottom,
-      {
-        x: 0,
-        y: 0,
-        skewY: 0,
-        scale: 1.0,
-        rotate: 0,
-      },
-      {
-        x: -10,
-        y: 10,
-        skewY: -7,
-        scaleX: 1.02,
-        scaleY: 1.3,
-        rotate: 7,
-        duration: 0.1,
-        ease: "power1.in",
-      },
-      "<",
-    )
-    .to(
-      textTop,
-      {
-        x: 0,
-        y: 0,
-        skewY: 0,
-        scale: 1.0,
-        rotate: 180,
-        duration: 0.1,
-        ease: "power1.in",
-      },
-      "<4.0",
-    )
-    .to(
-      textBottom,
-      {
-        x: 0,
-        y: 0,
-        skewY: 0,
-        scale: 1.0,
-        rotate: 0,
-        duration: 0.1,
-        ease: "power1.in",
-      },
-      "<",
-    );
+  const createTimeline = (selector: HTMLElement) => {
+    let tl = gsap.timeline({
+      delay: 3.0,
+      repeat: -1,
+      repeatDelay: 6.0,
+    });
 
-  return tl;
+    startTextGradientAnimation({
+      selector,
+      tl,
+      faded: true,
+      opacity: 0.05,
+    });
+
+    tl.timeScale(0.7);
+    return tl;
+  };
+
+  createTimeline(textTop as HTMLElement);
+  createTimeline(textBottom as HTMLElement);
 };
 
 export default startMenuBgAnimation;


### PR DESCRIPTION
## 概要
SPメニューの背景にグラデーションアニメーションを追加

## 主な変更点
- startMenuBgAnimationのtimeline変更・startTextGradientAnimationの呼び出し
- startTextGradientAnimationの引数の値にfaded, opacityを追加し、薄めのグラデーションのアニメーションと最終的な透過度を指定できるよう追記

## 関連するIssue
- feat/menu-bg-animation