### PR TITLE
fix: リロード時にスクロール位置をトップに戻る処理を追記

### DIFF
--- a/src/animations/resetScrollTriggers/managers/initScrollTriggerManager.ts
+++ b/src/animations/resetScrollTriggers/managers/initScrollTriggerManager.ts
@@ -9,10 +9,10 @@ export const addScrollTriggerFns = (fn: CreateTimelinesFn) => {
 
 export const runAllScrollTriggers = () => {
   // startConceptCatchAnimationが初回呼び出されたタイミングでのみ実行できれば良いので不要　※この関数を再利用するようであればコメントアウト解除！
-  // scrollTriggerTls.forEach((tl) => {
-  //   tl.kill();
-  // });
-  // scrollTriggerTls.clear();
+  scrollTriggerTls.forEach((tl) => {
+    tl.kill();
+  });
+  scrollTriggerTls.clear();
 
   createScrollTriggerFns.forEach((fn) => {
     const result = fn();

--- a/src/animations/resetScrollTriggers/managers/resetScrollTriggerTls.ts
+++ b/src/animations/resetScrollTriggers/managers/resetScrollTriggerTls.ts
@@ -29,6 +29,7 @@ const resetScrollTriggerTls = () => {
 
   //配列を展開して値である各timelineを(再)生成
   runAllScrollTriggers();
+  console.log("resetScrollTriggerTls run");
 };
 
 export default resetScrollTriggerTls;

--- a/src/libs/reload.ts
+++ b/src/libs/reload.ts
@@ -1,16 +1,17 @@
 const reload = () => {
-  const rootEl = document.getElementById("page-root");
-  let initialWidth = window.innerWidth;
-
-  if (rootEl) {
-    rootEl.dataset.color = "light";
-  }
+  history.scrollRestoration = "manual";
+  let width = window.innerWidth;
 
   window.addEventListener("resize", () => {
-    if (initialWidth !== window.innerWidth) {
+    if (width === window.innerWidth) {
+      return;
+    } else {
+      width = window.innerWidth;
       window.location.reload();
     }
   });
+
+  window.addEventListener("pageshow", () => window.scrollTo(0, 0));
 };
 
 export default reload;


### PR DESCRIPTION
## 概要
リロード時にスクロール位置をトップに戻る処理を追記

## 主な変更点
- リロード時にhistory.scrollRestoration = "manual"にてブラウザによるスクロール位置の復元を阻止、その後スクロール位置をトップに戻す処理を追記
- リサイズ時にもreloadを行うよう設定
- リサイズ及びリロード時に必ずスクロール位置はトップに戻るので、#page-rootのdatasetを指定する処理は不要のため削除

## 補足
- ローディングアニメーション(startLoaderAnimation)はAstroの高速表示を活かすため、現在は短め且つ同期処理

## 関連するIssue
- fix/reload