### PR TITLE
fix: DevToolsでのバグチェック(スマホ・タブレット回転時のリロードの修正)

### DIFF
--- a/src/libs/reload.ts
+++ b/src/libs/reload.ts
@@ -11,6 +11,8 @@ const reload = () => {
     }
   });
 
+  window.addEventListener("orientationchange", () => window.location.reload());
+
   window.addEventListener("pageshow", () => window.scrollTo(0, 0));
 };
 


### PR DESCRIPTION
## 概要
DevToolsでのバグチェック(スマホ・タブレット回転時のリロードの修正)

## 主な変更点
- スマホ・タブレットの回転時にリロードが発火されない時があったため、
window.addEventListener("orientationchange", () => window.location.reload());
を追記

## 関連するIssue
- fix/bug-check