### PR TITLE
fix: DevToolsにてバグチェック(Conceptコンポーネントのキャッチコピーのアニメーション調整)

### DIFF
--- a/src/components/Concept/index.astro
+++ b/src/components/Concept/index.astro
@@ -59,7 +59,9 @@ import BoldText from "@/components/BoldText.astro";
 </section>
 
 <script>
-  import startConceptCatchAnimation from "./startConceptCatchAnimation";
+  import startConceptCatchFillAnimation from "./startConceptCatchFillAnimation";
+  import startConceptCatchSkewAnimation from "./startConceptCatchSkewAnimation";
 
-  startConceptCatchAnimation();
+  startConceptCatchFillAnimation();
+  startConceptCatchSkewAnimation();
 </script>

--- a/src/components/Concept/startConceptCatchFillAnimation.ts
+++ b/src/components/Concept/startConceptCatchFillAnimation.ts
@@ -1,10 +1,7 @@
 import { gsap } from "gsap";
 import { ScrollTrigger } from "gsap/ScrollTrigger";
-import resetScrollTriggerTls from "@/animations/resetScrollTriggers/managers/resetScrollTriggerTls";
 
-const startConceptCatchAnimation = () => {
-  gsap.registerPlugin(ScrollTrigger);
-
+const startConceptCatchFillAnimation = () => {
   const trigger = document.getElementById("concept-catch");
   const conceptCatchEl = trigger?.querySelector("span");
   const catchSize = conceptCatchEl?.clientHeight;
@@ -14,17 +11,16 @@ const startConceptCatchAnimation = () => {
     .getElementById("catch-scroll")
     ?.querySelector("span");
 
-  let isFirst: boolean = true;
-
   if (catchSize && conceptCatchEl && trigger && scrollCatchEl) {
+    gsap.registerPlugin(ScrollTrigger);
+
     const offset = Number(catchSize + 50);
 
-    const tl = gsap.timeline({
+    gsap.timeline({
       scrollTrigger: {
         trigger,
+        id: "catchFill",
         start: `top -${offset}px`,
-        scrub: true,
-        markers: true,
         onEnter: () => {
           trigger.classList.remove("fixed");
           conceptFixed?.classList.remove("h-lvh");
@@ -43,29 +39,7 @@ const startConceptCatchAnimation = () => {
         },
       },
     });
-
-    tl.fromTo(
-      scrollCatchEl,
-      {
-        skewY: 0,
-        scaleX: 1.0,
-        scaleY: 1.0,
-        rotate: 0,
-      },
-      {
-        skewY: 12,
-        scaleX: 1.05,
-        scaleY: 1.6,
-        rotate: -12,
-        onComplete: () => {
-          if (isFirst) {
-            isFirst = false;
-            resetScrollTriggerTls();
-          }
-        },
-      },
-    );
   }
 };
 
-export default startConceptCatchAnimation;
+export default startConceptCatchFillAnimation;

--- a/src/components/Concept/startConceptCatchSkewAnimation.ts
+++ b/src/components/Concept/startConceptCatchSkewAnimation.ts
@@ -1,0 +1,50 @@
+import { gsap } from "gsap";
+import { ScrollTrigger } from "gsap/ScrollTrigger";
+import resetScrollTriggerTls from "@/animations/resetScrollTriggers/managers/resetScrollTriggerTls";
+
+const startConceptCatchSkewAnimation = () => {
+  const trigger = document.getElementById("concept");
+  const scrollCatchEl = document
+    .getElementById("catch-scroll")
+    ?.querySelector("span");
+
+  if (trigger && scrollCatchEl) {
+    gsap.registerPlugin(ScrollTrigger);
+
+    let isFirst: boolean = true;
+
+    const tl = gsap.timeline({
+      scrollTrigger: {
+        trigger,
+        id: "catchSkew",
+        start: "top 50%",
+        end: "bottom 80%",
+        scrub: true,
+      },
+    });
+
+    tl.fromTo(
+      scrollCatchEl,
+      {
+        skewY: 0,
+        scaleX: 1.0,
+        scaleY: 1.0,
+        rotate: 0,
+      },
+      {
+        skewY: 12,
+        scaleX: 1.05,
+        scaleY: 1.6,
+        rotate: -12,
+        onComplete: () => {
+          if (isFirst) {
+            isFirst = false;
+            resetScrollTriggerTls();
+          }
+        },
+      },
+    );
+  }
+};
+
+export default startConceptCatchSkewAnimation;


### PR DESCRIPTION
## 概要
Conceptコンポーネントのキャッチコピーのアニメーション調整

## 主な変更点
- ScrollTriggerのtriggerの大きさが変化するため、scrub:trueが効いてなく見えたためstartConceptCatchAnimationのクラス名付与の処理とfromToの処理のtriggerを別にし、2つのtimelineを生成するよう修正

## 関連するIssue
- fix/animation-trigger