### PR TITLE
fix: DevToolsでのバグチェック(メニューとHeroの配置・大きさの修正)

### DIFF
--- a/src/components/Hero/index.astro
+++ b/src/components/Hero/index.astro
@@ -3,7 +3,7 @@ import Catch from "@/components/Catch.astro";
 import HeroSlider from "./HeroSlider.astro";
 ---
 
-<section id="hero" class="relative h-lvh w-lvw">
+<section id="hero" class="relative h-svh w-svw">
   <div class="hero-fixed fixed top-0 left-0 h-full w-full p-1 md:p-2">
     <Catch others="hero-catch bottom-2 xl:bottom-9 min-[1728px]:bottom-11" />
     <HeroSlider />

--- a/src/components/Menu/index.astro
+++ b/src/components/Menu/index.astro
@@ -33,7 +33,7 @@ const barClass = (position: "top" | "middle" | "bottom") =>
   id="sp-menu"
   class="sp-menu invisible absolute top-0 left-0 h-screen w-screen lg:hidden"
 >
-  <nav id="sp-nav" class="flex h-full w-full items-center">
+  <nav id="sp-nav" class="flex h-svh w-svw items-center">
     <ul class="flex flex-col p-2">
       {
         headerLinksData.map((link) => (


### PR DESCRIPTION
## 概要
メニューとHeroの配置・大きさの修正

## 主な変更点
- タブレットで閲覧時のメニュー背景のテキスト位置の修正
- アドレスバー・ツールバーを考え、SPメニューとHeroコンポーネントの幅・高さの値を100svw, 100svhに修正

## 関連するIssue
- fix/responsive-ui