### PR TITLE
fix: DevToolsでのバグチェック(Conceptのキャッチコピーアニメーション部分の大きさ修正)

### DIFF
--- a/src/components/Concept/index.astro
+++ b/src/components/Concept/index.astro
@@ -7,7 +7,7 @@ import BoldText from "@/components/BoldText.astro";
   id="concept"
   class="relative overflow-hidden portrait:lg:overflow-visible"
 >
-  <div id="concept-fixed" class="relative h-lvh w-lvw p-1 md:p-2">
+  <div id="concept-fixed" class="relative h-svh w-svw p-1 md:p-2">
     <div
       id="concept-catch"
       class="concept-catch fixed top-0 left-0 h-full w-full"


### PR DESCRIPTION
## 概要
Conceptのキャッチコピーアニメーション部分の大きさ修正

## 主な変更点
- .concept-fixedの高さもHeroコンポーネントと同じく修正

## 関連するIssue
- fix/responsive-ui