### PR TITLE
fix: DevToolsでのバグチェック(mouseenterイベントでカーソル位置の補正を行うよう修正)

### DIFF
--- a/src/components/Cursor/createCursorFadeInTl.ts
+++ b/src/components/Cursor/createCursorFadeInTl.ts
@@ -1,12 +1,15 @@
 import { gsap } from "gsap";
 
-const createCursorFadeInTl = (cursor: HTMLElement) => {
-  const tl = gsap.timeline({ paused: true });
-  tl.fromTo(
+const createCursorFadeInTl = (cursor: HTMLElement, e: MouseEvent) => {
+  const tl = gsap.timeline();
+
+  tl.set(cursor, { scale: 0, opacity: 0 }).fromTo(
     cursor,
     {
-      scale: 0,
-      opacity: 0,
+      x: e.clientX,
+      y: e.clientY,
+      xPercent: -50,
+      yPercent: -50,
     },
     {
       scale: 1,

--- a/src/components/Cursor/createCursorFadeOutTl.ts
+++ b/src/components/Cursor/createCursorFadeOutTl.ts
@@ -1,0 +1,23 @@
+import { gsap } from "gsap";
+
+const createCursorFadeOutTl = (cursor: HTMLElement) => {
+  const tl = gsap.timeline();
+
+  tl.fromTo(
+    cursor,
+    {
+      scale: 1,
+      opacity: 0.8,
+    },
+    {
+      scale: 0,
+      opacity: 0,
+      duration: 0.3,
+      ease: "power1.in",
+    },
+  );
+
+  return tl;
+};
+
+export default createCursorFadeOutTl;

--- a/src/components/Cursor/createCursorFollowTl.ts
+++ b/src/components/Cursor/createCursorFollowTl.ts
@@ -1,8 +1,8 @@
 import { gsap } from "gsap";
 
 const createCursorFollowTl = (cursor: HTMLElement) => {
-  const xTo = gsap.quickTo(cursor, "x", { duration: 0.2 });
-  const yTo = gsap.quickTo(cursor, "y", { duration: 0.2 });
+  const xTo = gsap.quickTo(cursor, "x");
+  const yTo = gsap.quickTo(cursor, "y");
 
   return {
     xTo,

--- a/src/libs/enableCursorEffect.ts
+++ b/src/libs/enableCursorEffect.ts
@@ -1,8 +1,9 @@
 import createCursorFadeInTl from "@/components/Cursor/createCursorFadeInTl";
+import createCursorFadeOutTl from "@/components/Cursor/createCursorFadeOutTl";
 import createCursorFollowTl from "@/components/Cursor/createCursorFollowTl";
 
 const enableCursorEffect = (link: HTMLElement) => {
-  const cursor = document.querySelector(".custom-cursor");
+  const cursor: HTMLElement | null = document.querySelector(".custom-cursor");
 
   if (
     !cursor ||
@@ -10,19 +11,20 @@ const enableCursorEffect = (link: HTMLElement) => {
   )
     return;
 
-  const corsorFadeInTl = createCursorFadeInTl(cursor as HTMLElement);
-  const corsorFollowTl = createCursorFollowTl(cursor as HTMLElement);
-
   let isHover = false;
+  let fadeTl: GSAPTimeline | null = null;
+  const corsorFollowTl = createCursorFollowTl(cursor);
 
-  link.addEventListener("mouseenter", () => {
+  link.addEventListener("mouseenter", (e) => {
     isHover = true;
-    corsorFadeInTl.play();
+    fadeTl?.kill();
+    fadeTl = createCursorFadeInTl(cursor, e);
   });
 
   link.addEventListener("mouseleave", () => {
     isHover = false;
-    corsorFadeInTl.reverse();
+    fadeTl?.kill();
+    fadeTl = createCursorFadeOutTl(cursor);
   });
 
   link.addEventListener("mousemove", (e) => {


### PR DESCRIPTION
## 概要
追従カーソルのカーソル位置の補正

## 主な変更点
- mouseenterイベントでカーソル位置を一度補正するよう修正
- そのため、mouseenter, mouseleaveで生成されるtimelineを別々に記述
- 複数のtimelineの取り扱いが生じるめ、enableCursorEffectにて制御
- gsap.quickToのdurationを調整(デフォルトを使用することにしたため、durationは削除済)

## 関連するIssue
- fix/cursor-animation