### PR TITLE
fix: GitHub Pagesのビルド時のエラー解消とiconのパスの修正

### DIFF
--- a/src/layout/Layout.astro
+++ b/src/layout/Layout.astro
@@ -13,7 +13,7 @@ import Main from "@/components/Main.astro";
       checkFirstVisit();
     </script>
     <meta charset="utf-8" />
-    <link rel="icon" type="image/svg+xml" href="/logo.png" />
+    <link rel="icon" type="image/svg+xml" href="./images/logo.png" />
     <meta name="viewport" content="width=device-width" />
     <meta name="generator" content={Astro.generator} />
     <title>△△ inc. | suchのデモページだよ~</title>


### PR DESCRIPTION
## 概要
GitHub Pagesのビルド時のエラー解消とiconのパスの修正

## 主な変更点
- GitHub Pagesにてビルド時にエラーが出るため.nojekyllを設置
- iconのパスの修正