### PR TITLE
fix: 画像のパスの修正・Heroセクションの高さの固定

### DIFF
--- a/src/components/Arrow.astro
+++ b/src/components/Arrow.astro
@@ -9,7 +9,7 @@ interface Props {
 const { lg = false, others } = Astro.props as Props;
 
 const arrowStyle = cn(
-  "bg-[url('images/arrow.webp')] bg-no-repeat bg-contain lg:h-[10px] lg:w-12",
+  "bg-[url('/images/arrow.webp')] bg-no-repeat bg-contain lg:h-[10px] lg:w-12",
   {
     "h-[10px] w-[50px]": lg,
     "h-[7px] w-[33px]": !lg,

--- a/src/components/Hero/index.astro
+++ b/src/components/Hero/index.astro
@@ -4,7 +4,7 @@ import HeroSlider from "./HeroSlider.astro";
 ---
 
 <section id="hero" class="relative h-svh w-svw">
-  <div class="hero-fixed fixed top-0 left-0 h-full w-full p-1 md:p-2">
+  <div class="hero-fixed fixed top-0 left-0 h-svh w-full p-1 md:p-2">
     <Catch id="hero-catch" h1={true} others="bottom-0 z-10" />
     <HeroSlider />
   </div>


### PR DESCRIPTION
## 概要
画像のパスの修正・Heroセクションの高さの固定

## 主な変更点
- arrowのパスの修正
- スマホでスクロール時にUIバーの非表示によりHeroの高さが変わるため修正

## 関連するIssue
- prod/fix/catch-animation