### PR TITLE
fix: Heroと高さを合わせるため#catch-cloneを囲うdiv要素の追加

### DIFF
--- a/src/components/Concept/index.astro
+++ b/src/components/Concept/index.astro
@@ -5,9 +5,11 @@ import Catch from "@/components/Catch.astro";
 
 <section
   id="concept"
-  class="relative overflow-hidden bg-white p-1 md:p-2 portrait:lg:overflow-visible"
+  class="relative overflow-hidden bg-white portrait:lg:overflow-visible"
 >
-  <Catch id="catch-clone" others="fixed bottom-0 opacity-10" />
+  <div id="concept-fixed" class="fixed top-0 left-0 h-svh w-svw">
+    <Catch id="catch-clone" others="absolute bottom-0 opacity-10" />
+  </div>
   <div class="container-base m-auto">
     <Catch
       id="catch-scroll"

--- a/src/components/Concept/startConceptCatchAnimation.ts
+++ b/src/components/Concept/startConceptCatchAnimation.ts
@@ -12,10 +12,10 @@ gsap.registerPlugin(ScrollTrigger);
  */
 const startConceptCatchAnimation = () => {
   const trigger = document.getElementById("catch-scroll");
-  const fixedCatch = document.getElementById("catch-clone");
+  const fixedEl = document.getElementById("concept-fixed");
   const mainEl = document.getElementById("concept-main");
 
-  if (!trigger || !fixedCatch || !mainEl) return;
+  if (!trigger || !fixedEl || !mainEl) return;
 
   let isFirst: boolean = true;
 
@@ -27,12 +27,12 @@ const startConceptCatchAnimation = () => {
       end: "top top",
       scrub: true,
       onEnter: () => {
-        fixedCatch.classList.add("hidden");
+        fixedEl.classList.add("hidden");
         trigger.classList.remove("hidden");
         mainEl.classList.replace("opacity-0", "opacity-100");
       },
       onLeaveBack: () => {
-        fixedCatch.classList.remove("hidden");
+        fixedEl.classList.remove("hidden");
         trigger.classList.add("hidden");
         mainEl.classList.replace("opacity-100", "opacity-0");
       },


### PR DESCRIPTION
## 概要
Heroと高さを合わせるため#catch-cloneを囲うdiv要素の追加

## 主な変更点
- Heroに高さを合わせるため、#catch-cloneを囲うdiv要素の追加し.h-svhクラスを付与
- アニメーションにて使用するDOM要素をdiv要素に変更

## 関連するIssue
- prod/fix/catch-animation