### PR TITLE
fix: ScrollTriggerのstart位置をアニメーション発火時のビューポートの高さに修正

### DIFF
--- a/src/components/Concept/startConceptCatchAnimation.ts
+++ b/src/components/Concept/startConceptCatchAnimation.ts
@@ -23,7 +23,7 @@ const startConceptCatchAnimation = () => {
     scrollTrigger: {
       trigger,
       id: "catchAnimation",
-      start: "bottom bottom",
+      start: () => `bottom ${window.innerHeight}`,
       end: "top top",
       scrub: true,
       onEnter: () => {


### PR DESCRIPTION
## 概要
お問い合わせフォームの新規作成。

## 主な変更点
- スマホ時のスクロールにてキャッチコピーアインメーションがズレるので、ScrollTriggerのstart位置をアニメーション発火時のビューポートの高さに修正

## 関連するIssue
- prod/fix/catch-animation