### PR TITLE
fix: キャッチコピーのScrollTriggerのtrigger位置がずれないよう先にfixed要素の高さを固定

### DIFF
--- a/src/components/Concept/startConceptCatchAnimation.ts
+++ b/src/components/Concept/startConceptCatchAnimation.ts
@@ -12,16 +12,17 @@ gsap.registerPlugin(ScrollTrigger);
  * - これらの要素の非表示/表示により、同一の要素(キャッチコピー)が固定を解除されscale, skewが変化するかのような演出。
  */
 const startConceptCatchAnimation = () => {
-  const trigger = document.getElementById("catch-scroll");
   const fixedEl = document.getElementById("concept-fixed");
-  const mainEl = document.getElementById("concept-main");
-
-  if (!trigger || !fixedEl || !mainEl) return;
-
-  let isFirst: boolean = true;
-
+  if (!fixedEl) return;
   //スマホのUIバー対策のため、fixedElの高さをビューポートに合わせる
   setupElementHeight(fixedEl);
+
+  const trigger = document.getElementById("catch-scroll");
+  const mainEl = document.getElementById("concept-main");
+
+  if (!trigger || !mainEl) return;
+
+  let isFirst: boolean = true;
 
   const tl = gsap.timeline({
     scrollTrigger: {


### PR DESCRIPTION
## 概要
キャッチコピーのScrollTriggerのtrigger位置がずれないよう先にfixed要素の高さを固定

## 主な変更点
- #concept-fixedの高さを指定してからキャッチコピーのScrollTriggerを用いたTimelineを生成するよう修正

## 関連するIssue
- prod/fix/catch-animation