### PR TITLE
fix: キャッチコピーアニメーションのstart位置をビューポートの高さを用いて再設定

### DIFF
--- a/src/components/Concept/startConceptCatchAnimation.ts
+++ b/src/components/Concept/startConceptCatchAnimation.ts
@@ -28,7 +28,7 @@ const startConceptCatchAnimation = () => {
     scrollTrigger: {
       trigger,
       id: "catchAnimation",
-      start: "bottom bottom",
+      start: `bottom ${window.innerHeight}px`,
       end: "top top",
       scrub: true,
       onEnter: () => {


### PR DESCRIPTION
## 概要
キャッチコピーアニメーションのstart位置をビューポートの高さを用いて再設定

## 主な変更点
- startConceptCatchAnimationのScrollTrigger内、start: `bottom ${window.innerHeight}px`,に再設定

## 関連するIssue
- prod/fix/catch-animation