### PR TITLE
fix: ScrollTriggerのmarkersの削除

### DIFF
--- a/src/animations/enableHeaderColorWhite.ts
+++ b/src/animations/enableHeaderColorWhite.ts
@@ -41,7 +41,6 @@ const enableHeaderColorWhite = () => {
       id: "menu-color",
       start: "top top",
       end: "bottom+=10% bottom",
-      markers: true,
       toggleClass: { targets: menuLinks, className: "text-white" },
       onEnter: showWhiteLogo,
       onLeave: showBlackLogo,


### PR DESCRIPTION
## 概要
ScrollTriggerのmarkersの削除

## 主な変更点
- enableHeaderColorWhiteのmaekers: falseに修正

## 関連するIssue
- prod/fix/resetScrollTriggers