### PR TITLE
fix: companyセクション背景画像の高さも100svhに修正

### DIFF
--- a/src/components/Company/index.astro
+++ b/src/components/Company/index.astro
@@ -44,7 +44,7 @@ import companyBgImgData from "@/data/company/companyBgImgData";
         others="company-arrow absolute right-4 md:right-10 bottom-5 md:bottom-10 z-20 duration-300 peer-hover/company:translate-x-3"
       />
       <div
-        class="company-bg absolute top-1 left-1 h-[calc(100vh-8px)] w-[calc(100vw-8px)] duration-300 peer-hover/company:opacity-95 md:top-2 md:left-2 md:h-[calc(100vh-16px)] md:w-[calc(100vw-16px)]"
+        class="company-bg absolute top-1 left-1 h-[calc(100svh-8px)] w-[calc(100vw-8px)] duration-300 peer-hover/company:opacity-95 md:top-2 md:left-2 md:h-[calc(100svh-16px)] md:w-[calc(100vw-16px)]"
       >
         <div class="absolute z-10 h-full w-full rounded bg-black opacity-60">
         </div>


### PR DESCRIPTION
## 概要
companyセクション背景画像の高さも100svhに修正

## 主な変更点
- セクション自体の高さの変更に合わせ背景画像の高さも修正

## 関連するIssue
- prod/fix/pin-animation