### PR TITLE
fix: liタグにリンク要素の役割を追加した箇所をaタグを追加しに修正

### DIFF
--- a/src/components/News/NewsItem.astro
+++ b/src/components/News/NewsItem.astro
@@ -5,19 +5,17 @@ import newsItemsData from "@/data/news/newsItems";
 <ul class="news-articles">
   {
     newsItemsData.map((item) => (
-      <li
-        role="link"
-        tabindex="0"
-        class="group/item cursor-pointer border-b border-zinc-300 px-2 py-7 first:border-y md:py-8 lg:px-0 lg:py-8 xl:py-10 2xl:py-14"
-      >
-        <span class="flex-col duration-200 group-hover/item:opacity-50 lg:flex lg:flex-row lg:items-center">
-          <p class="font-menu pb-2 text-xs lg:pb-0 lg:pl-12 lg:text-base">
-            {item.date}
-          </p>
-          <h3 class="text-sm tracking-[0.15em] lg:pl-24 lg:text-xl">
-            {item.title}
-          </h3>
-        </span>
+      <li class="group/item cursor-pointer border-b border-zinc-300 px-2 py-7 first:border-y md:py-8 lg:px-0 lg:py-8 xl:py-10 2xl:py-14">
+        <a href="#" class="block">
+          <span class="flex-col duration-200 group-hover/item:opacity-50 lg:flex lg:flex-row lg:items-center">
+            <p class="font-menu pb-2 text-xs lg:pb-0 lg:pl-12 lg:text-base">
+              {item.date}
+            </p>
+            <h3 class="text-sm tracking-[0.15em] lg:pl-24 lg:text-xl">
+              {item.title}
+            </h3>
+          </span>
+        </a>
       </li>
     ))
   }

--- a/src/components/Service/index.astro
+++ b/src/components/Service/index.astro
@@ -16,27 +16,25 @@ import SectionTitle from "@/components/SectionTitle.astro";
     >
       {
         serviceItemsData.map((item) => (
-          <li
-            role="link"
-            tabindex="0"
-            class="group/item relative h-full cursor-pointer pb-4 md:w-3/10"
-          >
-            <span class="font-en absolute top-4 right-px z-10 pt-4 text-[50px] leading-1 text-white opacity-40 drop-shadow-md md:pt-0 md:text-3xl md:leading-none md:opacity-20 md:drop-shadow xl:text-5xl 2xl:text-6xl">
-              {item.en}
-            </span>
-            <div class="relative h-full">
-              <div class="absolute h-full w-full rounded bg-black opacity-5 duration-300 group-hover/item:opacity-0 md:opacity-20" />
-              <img src={item.src} class="w-full rounded" alt={item.text} />
-            </div>
-            <div class="relative z-10 w-full -translate-y-6">
-              <div class="relative z-10 flex items-end justify-between px-2 pb-3 lg:pr-4">
-                <p class="origin-bottom-left text-4xl leading-none font-bold text-white drop-shadow duration-300 group-hover/item:scale-101 md:text-xl lg:text-2xl xl:text-4xl 2xl:text-5xl">
-                  {item.text}
-                </p>
-                <Arrow others="delay-150 duration-300 group-hover/item:translate-x-1" />
+          <li class="group/item relative h-full pb-4 md:w-3/10">
+            <a href="#" class="block">
+              <span class="font-en absolute top-4 right-px z-10 pt-4 text-[50px] leading-1 text-white opacity-40 drop-shadow-md md:pt-0 md:text-3xl md:leading-none md:opacity-20 md:drop-shadow xl:text-5xl 2xl:text-6xl">
+                {item.en}
+              </span>
+              <div class="relative h-full">
+                <div class="absolute h-full w-full rounded bg-black opacity-5 duration-300 group-hover/item:opacity-0 md:opacity-20" />
+                <img src={item.src} class="w-full rounded" alt={item.text} />
               </div>
-              <span class="display absolute bottom-0 h-11 w-full rounded-b bg-black duration-300 group-hover/item:h-[72px] md:h-7 xl:h-[48px]" />
-            </div>
+              <div class="relative z-10 w-full -translate-y-6">
+                <div class="relative z-10 flex items-end justify-between px-2 pb-3 lg:pr-4">
+                  <p class="origin-bottom-left text-4xl leading-none font-bold text-white drop-shadow duration-300 group-hover/item:scale-101 md:text-xl lg:text-2xl xl:text-4xl 2xl:text-5xl">
+                    {item.text}
+                  </p>
+                  <Arrow others="delay-150 duration-300 group-hover/item:translate-x-1" />
+                </div>
+                <span class="display absolute bottom-0 h-11 w-full rounded-b bg-black duration-300 group-hover/item:h-[72px] md:h-7 xl:h-[48px]" />
+              </div>
+            </a>
           </li>
         ))
       }


### PR DESCRIPTION
## 概要
liタグにリンク要素の役割を追加した箇所をaタグを追加しに修正

## 主な変更点
- serviceセクションのliタグのrole="link" と tabindex=“0”を削除しaタグを追加
- newsセクションのliタグのrole="link" と tabindex=“0”を削除しaタグを追加

## 関連するIssue
- prod/fix/accessibility